### PR TITLE
Colony limit considers ONLY colonies in which the player is the leader

### DIFF
--- a/src/AntiGrief.cs
+++ b/src/AntiGrief.cs
@@ -526,7 +526,8 @@ namespace ColonyCommands {
 				int player_colonists = 0;
 				int killed_per_player = 0;
 				foreach (Colony checkColony in target.Colonies) {
-					player_colonists += checkColony.FollowerCount;
+					if(checkColony.Owners[0]  == target)
+						player_colonists += checkColony.FollowerCount;
 				}
 
 				// calculate effective limit to allow tier levels per player


### PR DESCRIPTION
This change has been made in GitHub **WITHOUT COMPILING**

When calculating the number of colonists per player you are considering ALL the colonies in which the player is, you should consider those in which the player is the leader.

Reason example:
Limit = 5000
Two players each one with a colony of 3000 colonists decide to share their colony.
Since 3.000+3000 > 5000 one of the colonies will lose colonists
